### PR TITLE
fix(result): day displayed instead of days if result is 1 day

### DIFF
--- a/src/app/date-calculator-form/date-calculator-form.component.html
+++ b/src/app/date-calculator-form/date-calculator-form.component.html
@@ -27,6 +27,6 @@
 </form>
 
 <div [hidden]="!displayResult" class="result row">
-  <h2>Result: {{duration}} days</h2>
-  <p>It is {{duration}} day(s) from the start date to the end date.</p>
+  <h2>Result: {{duration}} {{durationSuffix}}</h2>
+  <p>It is {{duration}} {{durationSuffix}} from the start date to the end date.</p>
 </div>

--- a/src/app/date-calculator-form/date-calculator-form.component.ts
+++ b/src/app/date-calculator-form/date-calculator-form.component.ts
@@ -18,6 +18,7 @@ export class DateCalculatorFormComponent  {
   duration =  null;
   endDateIncluded = false;
   displayResult = false;
+  durationSuffix = 'days';
 
 
   onSubmit() {  
@@ -32,6 +33,7 @@ export class DateCalculatorFormComponent  {
     if(this.endDateIncluded){
       this.duration += 1;
     }
+    this.durationSuffix = this.duration === 1 ? 'day' : 'days';
     this.displayResult = true;
   }
   


### PR DESCRIPTION
This PR Fixes typo if result is 1 day. It should be 'day' instead of 'days'

Before:
![image](https://user-images.githubusercontent.com/14028227/94842666-dbb10c80-0445-11eb-8b1d-faf22408e530.png)

After:
![image](https://user-images.githubusercontent.com/14028227/94842577-c2a85b80-0445-11eb-8f70-71aba6bed2e4.png)
